### PR TITLE
SND-8: changed subject validation to 200 chars

### DIFF
--- a/app/Http/Requests/EmailRequest.php
+++ b/app/Http/Requests/EmailRequest.php
@@ -32,7 +32,7 @@ class EmailRequest extends FormRequest
             'bcc' => 'sometimes|array|nullable',
             'bcc.*' => ['email', $formatEmail, 'max:320'],
             'from' => 'required|email',
-            'subject' => 'sometimes|string|max:100|nullable',
+            'subject' => 'sometimes|string|max:200|nullable',
             'body' => 'sometimes|string|nullable',
             "attachments" => 'sometimes|array',
             'attachments.*' => 'required|file|max:25600'

--- a/tests/Feature/EmailTest.php
+++ b/tests/Feature/EmailTest.php
@@ -523,4 +523,26 @@ class EmailTest extends TestCase
                 $emailInfo->getBody() === $email['body'];
         });
     }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function objectValidationTest()
+    {
+        Bus::fake();
+        Storage::fake('local');
+
+        $email = $this->getEmail();
+        $email['subject'] = Str::random(201);;
+        $response = $this->json('POST', '/api/v1/emails', $email);
+        $this->assertEquals(422, $response->status());
+        $response->assertJsonStructure([
+            "errors" => [
+                "subject"
+            ]
+        ]);
+
+        Bus::assertNotDispatched(EmailSender::class);
+    }
 }


### PR DESCRIPTION

Changed email subject validation from 100 chars to 200 chars.

Added test on subject validation